### PR TITLE
feat: 멘토링생성 시 세션 추가할 때 API 통신 추가 및 채팅 API 서버 API로 변경

### DIFF
--- a/apps/client/src/actions/mentoring/mentoringAction.ts
+++ b/apps/client/src/actions/mentoring/mentoringAction.ts
@@ -5,9 +5,14 @@ import {
   MentoringDataType,
   MentoringSessionDataType,
   MiddleCategoryDataType,
+  SessionTimeDataType,
+  SessionTimeValidationType,
   TopCategoryDataType,
 } from '../../components/types/main/mentor/mentoringTypes';
-import { commonResListType } from '../../components/types/ResponseTypes';
+import {
+  commonResListType,
+  commonResType,
+} from '../../components/types/ResponseTypes';
 
 const memberUuid = '671a55ae-2346-407f-85e3-9cd39f4e3d10';
 
@@ -135,4 +140,30 @@ export async function GetMentoringSessionList({
   }
 }
 
-//
+// 멘토링 세션 추가 시 시간이 스케쥴과 겹치는지 확인하는 API
+export async function PostSessionTimeValidation({
+  time,
+}: {
+  time: SessionTimeDataType;
+}) {
+  'use server';
+  console.log(time);
+  try {
+    const res = await fetch(
+      `${process.env.LOCAL_URL2}/api/v1/mentoring-service/validate-session-time?startDate=${time.startDate}&endDate=${time.endDate}&startTime=${time.startTime}&endTime=${time.endTime}&mentorUuid=${memberUuid}`,
+      {
+        cache: 'no-cache',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    const result =
+      (await res.json()) as commonResType<SessionTimeValidationType>;
+    return result.result;
+  } catch (error) {
+    console.error('세션 시간 검증 : ', error);
+    return null;
+  }
+}

--- a/apps/client/src/app/(main)/mentor/page.tsx
+++ b/apps/client/src/app/(main)/mentor/page.tsx
@@ -19,8 +19,8 @@ export default async function Page() {
           <span className="bg-slate-500 rounded-md py-1 px-2 text-white mr-2">
             안내
           </span>
-          {/* 현재 {}님의 멘토링은 {mentoringListData.length}개의 멘토링을 개설하고
-          있습니다. */}
+          현재 {}님의 멘토링은 {mentoringListData.length}개의 멘토링을 개설하고
+          있습니다.
         </p>
         <Link
           className="flex flex-row items-center bg-adaptorsGray text-md rounded-xl px-4 py-2 gap-x-2 text-white hover:bg-adaptorsBlue font-extrabold"

--- a/apps/client/src/components/pages/main/chatting/ChatViewMessage.tsx
+++ b/apps/client/src/components/pages/main/chatting/ChatViewMessage.tsx
@@ -29,12 +29,10 @@ function ChatViewMessage({ message }: { message: chatDataType }) {
   const formatDate = (dateArray: number[]) => {
     const [year, month, day, hour, minute, second, millisecond] = dateArray;
 
-    // Date 객체 생성 (month는 0부터 시작하므로 1을 빼줌)
     const date = new Date(
       Date.UTC(year, month - 1, day, hour, minute, second, millisecond)
     );
 
-    // 원하는 형식으로 변환
     return date.toLocaleString('ko-KR', {
       year: 'numeric',
       month: '2-digit',

--- a/apps/client/src/components/pages/main/chatting/Chatting.tsx
+++ b/apps/client/src/components/pages/main/chatting/Chatting.tsx
@@ -76,8 +76,8 @@ function Chatting({ participants }: { participants: participantType[] }) {
   };
 
   useEffect(() => {
-    // const chatServiceUrl = `http://3.35.228.51:8000/chat-service/api/v1/chat/real-time/${mentoringSessionUuid}`;
-    const chatServiceUrl = `http://10.10.10.149:51471/api/v1/chat/real-time/${mentoringSessionUuid}`;
+    const chatServiceUrl = `http://3.35.228.51:8000/chat-service/api/v1/chat/real-time/${mentoringSessionUuid}`;
+    // const chatServiceUrl = `http://10.10.10.149:51471/api/v1/chat/real-time/${mentoringSessionUuid}`;
     console.log(`Connecting to: ${chatServiceUrl}`);
 
     const eventSource = new EventSourcePolyfill(chatServiceUrl, {

--- a/apps/client/src/components/types/main/mentor/mentoringTypes.ts
+++ b/apps/client/src/components/types/main/mentor/mentoringTypes.ts
@@ -9,22 +9,43 @@ export interface MiddleCategoryDataType {
   middleCategoryName: string;
 }
 
-export interface MentoringSessionDataType {
-  startDate: Date;
-  endDate: Date;
-  startTime: Date;
-  endTime: Date;
-  deadlineDatetime: Date;
+// 멘토링 세션 시간 정보
+export interface SessionTimeDataType {
+  startDate: string;
+  endDate: string;
+  startTime: string;
+  endTime: string;
+}
+
+// 멘토링 세션 시간 RESPONSE DATA 타입
+export interface SessionTimeResType {
+  startDate: string[];
+  endDate: string[];
+  startTime: string[];
+  endTime: string[];
+}
+
+// 멘토링 세션 시간 검증 정보
+export interface SessionTimeValidationType {
+  isPossible: boolean;
+  timeDuplicateResponse: SessionTimeResType | null;
+}
+
+// 멘토링 세션 정보
+export interface MentoringSessionDataType extends SessionTimeDataType {
+  deadlinestringtime: Date;
   minHeadCount: number;
   maxHeadCount: number;
   price: number;
 }
 
+// 멘토링 카테고리 정보
 export interface MentoringCategoryDataType {
   topCategoryName: string;
   middleCategoryName: string;
 }
 
+// 멘토링 정보
 export interface MentoringDataType {
   id: string;
   mentoringId: string;


### PR DESCRIPTION
세션 추가 API 통신
실패할 경우 겹치는 시간 언제인지 알려주도록 SweetAlert 구현
채팅 API는 몽고DB가 서버에서는 연결되지 않아서 작동이 안되던 부분 백에서 수정 후 서버 API로 변경